### PR TITLE
Change outdated helm.fluxcd.io/v2beta1 references

### DIFF
--- a/docs/spec/v2beta1/helmreleases.md
+++ b/docs/spec/v2beta1/helmreleases.md
@@ -815,7 +815,7 @@ One can also opt-in to remediation of the last failure (when no retries remain) 
 to true if at least one retry is configured.
 
 ```yaml
-apiVersion: helm.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -898,7 +898,7 @@ subjects:
 Create a `HelmRelease` that prevents altering the cluster state outside of the `webapp` namespace:
 
 ```yaml
-apiVersion: helm.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: podinfo


### PR DESCRIPTION
I ran into this when I was perusing the docs looking for an example HelmRelease, these outdated mentions of `helm.fluxcd.io/v2beta1` can be changed to `helm.toolkit.fluxcd.io/v2beta1`